### PR TITLE
Add unit of measurement to Curtain Illuminance

### DIFF
--- a/Arduino IDE Files/SwitchBot-BLE2MQTT-ESP32.ino
+++ b/Arduino IDE Files/SwitchBot-BLE2MQTT-ESP32.ino
@@ -903,6 +903,7 @@ void publishHomeAssistantDiscoveryCurtainConfig(std::string deviceName, std::str
                  + "\"uniq_id\":\"switchbot_" + deviceMac + "_illuminance\"," +
                  + "\"stat_t\":\"~/attributes\"," +
                  + "\"dev_cla\":\"illuminance\"," +
+                 + "\"unit_of_meas\": \"Level\", " +
                  + "\"value_template\":\"{{ value_json.light }}\"}").c_str(), true);
 
   client.publish((home_assistant_mqtt_prefix + "/binary_sensor/" + deviceName + "/calibrated/config").c_str(), ("{\"~\":\"" + (curtainTopic + deviceName) + "\"," +

--- a/PlatformIO Files/SwitchBot-BLE2MQTT-ESP32/src/SwitchBot-BLE2MQTT-ESP32.cpp
+++ b/PlatformIO Files/SwitchBot-BLE2MQTT-ESP32/src/SwitchBot-BLE2MQTT-ESP32.cpp
@@ -903,6 +903,7 @@ void publishHomeAssistantDiscoveryCurtainConfig(std::string deviceName, std::str
                  + "\"uniq_id\":\"switchbot_" + deviceMac + "_illuminance\"," +
                  + "\"stat_t\":\"~/attributes\"," +
                  + "\"dev_cla\":\"illuminance\"," +
+                 + "\"unit_of_meas\": \"Level\", " +
                  + "\"value_template\":\"{{ value_json.light }}\"}").c_str(), true);
 
   client.publish((home_assistant_mqtt_prefix + "/binary_sensor/" + deviceName + "/calibrated/config").c_str(), ("{\"~\":\"" + (curtainTopic + deviceName) + "\"," +


### PR DESCRIPTION
Add unit of measurement = "Level"(same as Home Assistant default switchbot integration), then Home Assistant will show Illuminance History as graph.