### PR TITLE
Pin platform espressif32 to 3.5.0

### DIFF
--- a/PlatformIO Files/SwitchBot-BLE2MQTT-ESP32/platformio.ini
+++ b/PlatformIO Files/SwitchBot-BLE2MQTT-ESP32/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env]
-platform = espressif32
+platform = espressif32 @ ~3.5.0
 framework = arduino
 lib_deps = 
 	h2zero/NimBLE-Arduino@1.4.0


### PR DESCRIPTION
It's the last release on 1.0.6 (I think) before they moved to arduino 2.0 that seems to be causing some BLE issues.

Discussion on the 1.0.6 issue here: https://github.com/devWaves/SwitchBot-MQTT-BLE-ESP32/issues/90

reference: [platform-espressif32 3.5](https://github.com/platformio/platform-espressif32) vs [platform-espressif32 4.0.0](https://github.com/platformio/platform-espressif32/releases/tag/v4.0.0)
