### PR TITLE
Contributing community 'works on these' list

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,11 @@ by BangerTech (Language German. based on v6.1. OpenHab)
 * QuinLED-ESP32-AE
 * Heltec WiFi Kit 32
 
+**ESP32 models/boards that the community has confirmed as working**
+* ESP32-WROOM-32
+  * AZ-Delivery ESP32 Dev KitC v2 - SwitchBot-MQTT-BLE-ESP32 version 6.12
+  * AZ-Delivery ESP32 Dev KitC v4 - SwitchBot-MQTT-BLE-ESP32 version 6.12
+
 **ESP32 models that may not work**
 * ESP32-S2 = No Bluetooth so definitely won't work
 * ESP32-C3 = Less RAM/ROM that the WROOM models

--- a/README.md
+++ b/README.md
@@ -442,13 +442,13 @@ by BangerTech (Language German. based on v6.1. OpenHab)
 **ESP32 models that I can confirm work**
 * Wemos D1 Mini ESP32
 * ESP32-WROOM-32U
+* ESP32-WROOM-32
 * QuinLED-ESP32-AE
 * Heltec WiFi Kit 32
 
 **ESP32 models/boards that the community has confirmed as working**
-* ESP32-WROOM-32
-  * AZ-Delivery ESP32 Dev KitC v2 - SwitchBot-MQTT-BLE-ESP32 version 6.12
-  * AZ-Delivery ESP32 Dev KitC v4 - SwitchBot-MQTT-BLE-ESP32 version 6.12
+* AZ-Delivery ESP32 Dev KitC v2
+* AZ-Delivery ESP32 Dev KitC v4
 
 **ESP32 models that may not work**
 * ESP32-S2 = No Bluetooth so definitely won't work


### PR DESCRIPTION
I've successfully been using v6.12 on an AzDelivery ESP32 Dev Kit C ESP32-WROOM-32 v2 (version 2) for the last month or so with zero issues. Thought I'd contribute to say so.

I've just swapped over to a v4 of the same board, and again appear to be experiencing no issues.

Both were deployed with the `az-delivery-devkit-v4` profile in platformio and the `LED_BUILTIN` set to 1

I'll upgrade to 7.0+ in the coming weeks and report back then :)

No drama if each individual dev board is not a useful contribution; but with the variance between dev boards sometimes when you're a noob (like I was!) you need to see specifics to know whether something will work.