### PR TITLE
Add possible JSON payload coming in via MQTT for use with Domoticz

### DIFF
--- a/Arduino IDE Files/SwitchBot-BLE2MQTT-ESP32.ino
+++ b/Arduino IDE Files/SwitchBot-BLE2MQTT-ESP32.ino
@@ -5800,6 +5800,16 @@ bool controlMQTT(std::string & device, std::string payload, bool disconnectAfter
 
 
     String tempPayload = payload.c_str();
+	  
+    //payload might be JSON. Convert to valid payload
+    StaticJsonDocument<200> doc;
+    DeserializationError payloadError = deserializeJson(doc, tempPayload);
+    if (!payloadError) {
+      if (doc.containsKey("position")) {
+        tempPayload=doc["position"].as<String>();
+      }      
+    }
+	  
     int dotIndex = tempPayload.indexOf(".");
     if (dotIndex >= 0) {
       tempPayload.remove(dotIndex, tempPayload.length() - 1);


### PR DESCRIPTION
Add possible JSON payload coming in via MQTT.
This is needed for Domoticz. It used to send position requests for curtain using integers. Since the last update it uses {"position":< integer >} as payload via MQTT. Other commands like PAUSE are sent as STRINGs, not JSON.